### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -54,11 +54,11 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -42,11 +42,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -45,11 +45,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
여기서 필드에 직접 접근하면, 하이버네이트가 지연 로딩하려고 만든 프록시 객체를 다룰 때 필드값이 `null`일 수 있음 그러면 제대로 비교 로직을 수행 할 수 없기 때문에 getter를 이용함.
이것으로 프록시 객체를 타더라도 제대로 값을 읽어올 수 있음