### PR TITLE
[고도화] MySQL -- PostgreSQL

### DIFF
--- a/fastcampus-project-board/build.gradle
+++ b/fastcampus-project-board/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'  // start.spring.id 에서 디펜던시 추가 할때 타임리프도 같이 해줘야 extras:thymeleaf 이 부분을 확인 할 수 있다.
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -12,13 +12,15 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
+#    url: jdbc:mysql://localhost:3306/board
+    url: jdbc:postgresql://localhost:5432/board
 #    username: yhn
-    username: root
-#    password: 1234
-    password: root
+#    username: root
+    username: postgres
+    password: 1234
+#    password: root
 #    password: thisisTESTpw!@#$
-    driver-class-name: com.mysql.cj.jdbc.Driver
+#    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     defer-datasource-initialization: true
     hibernate:


### PR DESCRIPTION
드라이버는 자동 선택되므로 지우는 것이 더 효율적이다.
로컬에 postgresql을 install 하지 않고, docker 이용해서 postgre:15로 만들었다.

`docker run --name my_postgres -e POSTGRES_PASSWORD=1234 -p 5432:5432 -d postgres:15` `create database board`
`create user test with password '1234' `
user에 권한을 주지 않아서 스키마는 기본 public