### PR TITLE
[리팩토링] AuditingFields 의 잘못 표현된 부분 개선

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -23,19 +23,19 @@ public class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;    // 생성일시
+    protected LocalDateTime createdAt;    // 생성일시
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy;   // 생성자
+    protected String createdBy;   // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt;   // 수정일시
+    protected LocalDateTime modifiedAt;   // 수정일시
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy;  // 수정자
+    protected String modifiedBy;  // 수정자
 
 }


### PR DESCRIPTION
원래 이 부분은 abstract class에 맞게 `protected`여야 했는데 초기 설계에서 지나치게 닫힌 형태로 작업함

이제 회원 엔티티가 이 부분을 직접 참조해야하므로 제대로 수정
이것으로 생성자에서 인증 없이 회원 정보를 저장할 수 있음
필요한 시나리오 회원 가입, 회원 생성