### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수의 사용

### DIFF
--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -12,15 +12,9 @@ logging:
 
 spring:
   datasource:
-#    url: jdbc:mysql://localhost:3306/board
-    url: jdbc:postgresql://localhost:5432/board
-#    username: yhn
-#    username: root
-    username: postgres
-    password: 1234
-#    password: root
-#    password: thisisTESTpw!@#$
-#    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
   jpa:
     defer-datasource-initialization: true
     hibernate:
@@ -45,8 +39,6 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${KAKAO_OAUTH_CLIENT_ID}
-            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             client-authentication-method: client_secret_post


### PR DESCRIPTION
`properties.yaml`에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경쓰도록 한다.
그러나, 이미 과거 기록(커밋노드)을 조회하면 여전히 노출된 값을 볼 수 있기때문 
근본적인 해결을 하려면 이 저장소를 전체 삭제 후 새로 올리는 방법 밖에 없다.

